### PR TITLE
[WIP] Portfolio tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13197,6 +13197,12 @@
       "integrity": "sha512-WlQNtUlzMRpvLHf8dqeUmNqfdPjGY29KrJF50Ldb4AcL+vQeR8QH3wQcFMgrhTwb1gHjZn9xggho+84tBskLgA==",
       "dev": true
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
+    },
     "more-entropy": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "idb-wrapper": "^1.7.1",
     "local-web-server": "^2.5.2",
     "lodash": "^4.17.5",
+    "moment": "^2.22.2",
     "ngrok": "^3.1.0",
     "node-sass": "^4.9.2",
     "optimize-css-assets-webpack-plugin": "^3.2.0",

--- a/src/app/actions/portfolio.js
+++ b/src/app/actions/portfolio.js
@@ -24,9 +24,6 @@ export const portfolioAdded = createAction('PORTFOLIO_ADDED')
 
 export const removePortfolio = (id) => (dispatch) => Promise.resolve()
   .then(() => {
-    if (id === defaultPortfolioId) {
-      throw new Error('Cannot delete default portfolio');
-    }
     return dispatch(removeWallet(id))
   })
 

--- a/src/app/components/App/view.jsx
+++ b/src/app/components/App/view.jsx
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
+
+import RedirectPrefix from 'Components/RedirectPrefix'
 import Connect from 'Components/Connect'
 import TradeHistory from 'Components/TradeHistory'
 import WalletOpened from 'Components/WalletOpened'
@@ -30,7 +32,7 @@ const AppView = ({ hasNoWallets }) => (
       )} />
 
       {/* Routes requiring a connected wallet */}
-      <WalletOpened path={dashboard.path} component={Dashboard}/>
+      <WalletOpened exact path={dashboard.path} component={Dashboard}/>
       <WalletOpened path={rebalance.path} component={Modify}/>
 
       {/* Routes that don't require a connected wallet */}
@@ -47,6 +49,10 @@ const AppView = ({ hasNoWallets }) => (
       {/* Legacy routes */}
       <Redirect exact from='/balances' to={dashboard.path}/>
       <Redirect exact from='/modify' to={rebalance.path}/>
+      <Redirect exact from='/dashboard' to={dashboard.path}/>
+      <Redirect exact from='/orders' to={tradeHistory.path}/>
+      <RedirectPrefix from='/rebalance' to={rebalance.path}/>
+      <RedirectPrefix from='/connect' to={connect.path}/>
 
       {/* Fallback for unknown routes */}
       <Redirect to={dashboard.path}/>

--- a/src/app/components/AppNavbar.jsx
+++ b/src/app/components/AppNavbar.jsx
@@ -31,7 +31,7 @@ const AppNavbar = ({ children, isExpanded,
   <Navbar {...pick(props, Object.keys(Navbar.propTypes))}>
     <Container>
       <NavbarBrand tag={Link} to='/' className='mr-auto'>
-        <Icon src={FaastLogo} height='1.5rem' width='1.5rem' inline className='mx-3'/>Faast Portfolio <sup className='beta-tag'>beta</sup>
+        <Icon src={FaastLogo} height='1.5rem' width='1.5rem' inline className='mx-3'/>Faa.st <sup className='beta-tag'>beta</sup>
       </NavbarBrand>
       <NavbarToggler onClick={toggleExpanded} />
       <Collapse isOpen={isExpanded} navbar>

--- a/src/app/components/AppNavbar.jsx
+++ b/src/app/components/AppNavbar.jsx
@@ -26,7 +26,7 @@ import withToggle from 'Hoc/withToggle'
 import Icon from 'Components/Icon'
 import FaastLogo from 'Img/faast-logo.png'
 
-const AppNavbar = ({ disablePortfolioLinks, children, isExpanded, 
+const AppNavbar = ({ children, isExpanded, 
   toggleExpanded, isDropdownOpen, toggleDropdownOpen, ...props }) => (
   <Navbar {...pick(props, Object.keys(Navbar.propTypes))}>
     <Container>
@@ -36,14 +36,6 @@ const AppNavbar = ({ disablePortfolioLinks, children, isExpanded,
       <NavbarToggler onClick={toggleExpanded} />
       <Collapse isOpen={isExpanded} navbar>
         <Nav navbar>
-          {!disablePortfolioLinks && (
-            <NavItem key='dashboard'>
-              <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/dashboard'>
-                <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-pie-chart'/>
-                <span className='nav-link-label d-sm-inline'>Dashboard</span>
-              </NavLink>
-            </NavItem>
-          )}
           <Dropdown nav isOpen={isDropdownOpen} size="sm" toggle={toggleDropdownOpen} setActiveFromChild>
             <DropdownToggle 
               tag={RouterNavLink} 
@@ -65,32 +57,16 @@ const AppNavbar = ({ disablePortfolioLinks, children, isExpanded,
               <DropdownItem tag={Link} to={'/assets/watchlist'} className='text-muted py-2'>Watchlist</DropdownItem>
             </DropdownMenu>
           </Dropdown>
-          {!disablePortfolioLinks && ([
-            <NavItem key='rebalance'>
-              <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/rebalance'>
-                <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-sliders'/>
-                <span className='nav-link-label d-sm-inline'>Rebalance</span>
-              </NavLink>
-            </NavItem>
-          ])}
-          <NavItem key='swap'>
+          <NavItem>
             <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/swap'>
               <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-exchange'/>
               <span className='nav-link-label d-sm-inline'>Swap</span>
             </NavLink>
           </NavItem>
-          {!disablePortfolioLinks && (
-            <NavItem key='orders'>
-              <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/orders'>
-                <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-history'/>
-                <span className='nav-link-label d-sm-inline'>Orders</span>
-              </NavLink>
-            </NavItem>
-          )}
-          <NavItem key='connect'>
-            <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/connect'>
-              <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-plus'/>
-              <span className='nav-link-label d-sm-inline'>Add wallet</span>
+          <NavItem>
+            <NavLink className='px-1 px-lg-2' tag={RouterNavLink} to='/portfolio'>
+              <i className='d-inline d-md-none d-lg-inline nav-link-icon fa fa-pie-chart'/>
+              <span className='nav-link-label d-sm-inline'>Portfolio</span>
             </NavLink>
           </NavItem>
         </Nav>

--- a/src/app/components/Balances/index.jsx
+++ b/src/app/components/Balances/index.jsx
@@ -1,80 +1,24 @@
 import React, { Fragment } from 'react'
 import { createStructuredSelector } from 'reselect'
 import PropTypes from 'prop-types'
-import { Card, CardHeader, Col, Row, Dropdown, DropdownMenu, DropdownToggle,
-  DropdownItem
+import {
+  Card, CardHeader,
 } from 'reactstrap'
-import classNames from 'class-names'
 import { connect } from 'react-redux'
 
-import display from 'Utilities/display'
 import { getWalletWithHoldings } from 'Selectors'
 
 import withToggle from 'Hoc/withToggle'
 
-import ChangePercent from 'Components/ChangePercent'
 import LoadingFullscreen from 'Components/LoadingFullscreen'
 import AssetTable from 'Components/AssetTable'
-import ShareButton from 'Components/ShareButton'
 
-import { statLabel } from './style'
-
-const Balances = ({ wallet, handleRemove, isDropdownOpen, toggleDropdownOpen, 
-  handleAdd, isAlreadyInPortfolio, showStats }) => {
+const Balances = ({ wallet, header }) => {
   const {
-    address, assetHoldings, holdingsLoaded, holdingsError, label, totalFiat, 
-    totalFiat24hAgo, totalChange
+    assetHoldings, holdingsLoaded, holdingsError,
   } = wallet
 
   const assetRows = assetHoldings.filter(({ shown }) => shown)
-
-  const stats = [
-    {
-      title: 'total assets',
-      value: assetRows.length,
-      colClass: 'order-2 order-lg-1'
-    },
-    {
-      title: 'total balance',
-      value: display.fiat(totalFiat),
-      colClass: 'order-1 order-lg-2'
-    },
-    {
-      title: 'balance 24h ago',
-      value: display.fiat(totalFiat24hAgo),
-      colClass: 'order-3'
-    },
-    {
-      title: 'since 24h ago',
-      value: (<ChangePercent>{totalChange}</ChangePercent>),
-      colClass: 'order-4'
-    },
-  ]
-
-  const searchAndShare = (
-    (<Fragment>
-      <Col style={{ top: '2px' }} className='p-0 position-relative' xs='auto'>
-        <ShareButton wallet={wallet}/>
-      </Col>
-      <Col className='p-0 pr-2' xs='auto'>
-        <Dropdown group isOpen={isDropdownOpen} size="sm" toggle={toggleDropdownOpen}>
-          <DropdownToggle 
-            tag='div'
-            className='py-0 px-2 flat d-inline-block position-relative cursor-pointer' 
-          >
-            <i className="fa fa-ellipsis-v" aria-hidden="true"></i>
-          </DropdownToggle>
-          <DropdownMenu className='p-0' right>
-            {isAlreadyInPortfolio ? (
-              <DropdownItem className='py-2' onClick={handleRemove}>Remove Wallet</DropdownItem>
-            ) : (
-              <DropdownItem className='py-2' onClick={handleAdd}>Add Wallet</DropdownItem>
-            )}
-          </DropdownMenu>
-        </Dropdown>
-      </Col>
-    </Fragment>)
-  )
 
   return (
     <Fragment>
@@ -82,31 +26,8 @@ const Balances = ({ wallet, handleRemove, isDropdownOpen, toggleDropdownOpen,
         <LoadingFullscreen label='Loading balances...' error={holdingsError}/>
       )}
       <Card>
-        <CardHeader className={showStats ? 'grid-group' : null}>
-          {!showStats && (
-            <Col className='px-0' xs='12'>
-              <Row className='gutter-3 align-items-center'>
-                <Col className='px-2'>
-                  <h5>{address ? label : 'Portfolio'} Holdings</h5>
-                </Col>
-                {address ?
-                  searchAndShare
-                  : null}
-              </Row>
-            </Col>
-          )}
-          {showStats && (
-            <Row className='gutter-3'>
-              {stats.map(({ title, value, colClass }, i) => (
-                <Col xs='6' lg='3' key={i} className={classNames('text-center', colClass)}>
-                  <div className='grid-cell'>
-                    <div className='h3 mb-0'>{value}</div>
-                    <small className={classNames('mb-0', statLabel)}>{title}</small>
-                  </div>
-                </Col>
-              ))}
-            </Row>
-          )}
+        <CardHeader>
+          <h5>{header}</h5>
         </CardHeader>
         <AssetTable assetRows={assetRows}/>
       </Card>
@@ -119,12 +40,14 @@ Balances.propTypes = {
   handleRemove: PropTypes.func,
   handleAdd: PropTypes.func,
   isAlreadyInPortfolio: PropTypes.bool,
-  showStats: PropTypes.bool
+  showStats: PropTypes.bool,
+  header: PropTypes.string,
 }
 
 Balances.defaultProps = {
   isAlreadyInPortfolio: true,
-  showStats: false
+  showStats: false,
+  header: 'Holdings',
 }
 
 const ConnectedBalances = connect(createStructuredSelector({

--- a/src/app/components/Balances/index.jsx
+++ b/src/app/components/Balances/index.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import { createStructuredSelector } from 'reselect'
 import PropTypes from 'prop-types'
-import { Card, CardHeader, CardBody, Col, Row, Dropdown, DropdownMenu, DropdownToggle,
+import { Card, CardHeader, Col, Row, Dropdown, DropdownMenu, DropdownToggle,
   DropdownItem
 } from 'reactstrap'
 import classNames from 'class-names'
@@ -13,9 +13,7 @@ import { getWalletWithHoldings } from 'Selectors'
 import withToggle from 'Hoc/withToggle'
 
 import ChangePercent from 'Components/ChangePercent'
-import Address from 'Components/Address'
 import LoadingFullscreen from 'Components/LoadingFullscreen'
-import PieChart from 'Components/PieChart'
 import AssetTable from 'Components/AssetTable'
 import ShareButton from 'Components/ShareButton'
 
@@ -112,20 +110,6 @@ const Balances = ({ wallet, handleRemove, isDropdownOpen, toggleDropdownOpen,
         </CardHeader>
         <AssetTable assetRows={assetRows}/>
       </Card>
-      {assetRows.length > 0 && (<Card className='mt-3'>
-        <CardHeader>
-          <h5>Distribution</h5>
-        </CardHeader>
-        <CardBody>
-          {address && (
-            <div className='text-right' style={{ lineHeight: 1 }}>
-              <Address address={address} />
-              <small className='text-muted'>address</small>
-            </div>
-          )}
-          <PieChart portfolio={wallet} />
-        </CardBody>
-      </Card>)}
     </Fragment>
   )
 }

--- a/src/app/components/Balances/style.scss
+++ b/src/app/components/Balances/style.scss
@@ -1,7 +1,0 @@
-@import '~faast-ui/src/style/index';
-
-.statLabel {
-  @extend .text-muted;
-  @extend .text-uppercase;
-  @extend .letter-spacing;
-}

--- a/src/app/components/Dashboard/index.jsx
+++ b/src/app/components/Dashboard/index.jsx
@@ -3,8 +3,9 @@ import { connect } from 'react-redux'
 import { Redirect, withRouter } from 'react-router-dom'
 import { createStructuredSelector } from 'reselect'
 
+import routes from 'Routes'
 import {
-  getCurrentWalletWithHoldings, isDefaultPortfolioEmpty, getConnectedWalletsPendingSwaps
+  getCurrentWalletWithHoldings, isDefaultPortfolioEmpty, getConnectedWalletsRecentSwaps
 } from 'Selectors'
 import { updateAllHoldings, removePortfolio, defaultPortfolioId } from 'Actions/portfolio'
 
@@ -36,11 +37,11 @@ class Dashboard extends Component {
   }
 
   render () {
-    const { wallet, isDefaultPortfolioEmpty, pendingSwaps } = this.props
+    const { wallet, isDefaultPortfolioEmpty } = this.props
     const isViewOnly = wallet.isReadOnly
 
     if (isDefaultPortfolioEmpty && !isViewOnly) {
-      return (<Redirect to='/connect'/>)
+      return (<Redirect to={routes.connect()}/>)
     }
 
     const disableRemove = wallet.id === defaultPortfolioId
@@ -51,7 +52,6 @@ class Dashboard extends Component {
         viewOnly={isViewOnly}
         disableRemove={disableRemove}
         isDefaultPortfolioEmpty={isDefaultPortfolioEmpty}
-        pendingSwaps={pendingSwaps}
         {...this.props}
       />
     )
@@ -61,7 +61,7 @@ class Dashboard extends Component {
 const mapStateToProps = createStructuredSelector({
   wallet: getCurrentWalletWithHoldings,
   isDefaultPortfolioEmpty: isDefaultPortfolioEmpty,
-  pendingSwaps: getConnectedWalletsPendingSwaps
+  recentSwaps: getConnectedWalletsRecentSwaps,
 })
 
 const mapDispatchToProps = {

--- a/src/app/components/Dashboard/view.jsx
+++ b/src/app/components/Dashboard/view.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import {
   Row, Col, Card, CardHeader, CardBody,
+  UncontrolledDropdown, DropdownMenu, DropdownToggle, DropdownItem,
 } from 'reactstrap'
+
+import { defaultPortfolioId } from 'Actions/portfolio'
 
 import Layout from 'Components/Layout'
 import Balances from 'Components/Balances'
@@ -10,6 +13,8 @@ import WalletSelector from 'Components/WalletSelector'
 import Address from 'Components/Address'
 import PieChart from 'Components/PieChart'
 import SwapList from 'Components/SwapList'
+import ShareButton from 'Components/ShareButton'
+import WalletStats from 'Components/WalletStats'
 
 const DashboardView = (props) => {
   const {
@@ -29,6 +34,36 @@ const DashboardView = (props) => {
         <Col xs='12' md='7' lg='8' xl='9'>
           <Row className='gutter-3'>
             <Col xs='12'>
+              <Card>
+                <CardHeader>
+                  <Row className='gutter-3 align-items-center'>
+                    <Col className='px-2'>
+                      <h5>{wallet.label}</h5>
+                    </Col>
+                    <Col xs='auto'>
+                      <ShareButton wallet={wallet} className='py-0 align-baseline'/>
+                    </Col>
+                    <Col className='p-0 pr-2' xs='auto'>
+                      <UncontrolledDropdown group size='sm'>
+                        <DropdownToggle
+                          className='py-0 px-2 text-white'
+                          color='link'
+                        >
+                          <i className="fa fa-ellipsis-v fa-lg" aria-hidden="true"></i>
+                        </DropdownToggle>
+                        <DropdownMenu className='p-0' right>
+                          <DropdownItem className='py-2' onClick={handleRemove}>
+                            {wallet.id === defaultPortfolioId ? 'Remove all wallets' : 'Remove Wallet'}
+                          </DropdownItem>
+                        </DropdownMenu>
+                      </UncontrolledDropdown>
+                    </Col>
+                  </Row>
+                </CardHeader>
+                <WalletStats tag={CardBody} wallet={wallet}/>
+              </Card>
+            </Col>
+            <Col xs='12'>
               <Balances 
                 wallet={wallet} 
                 toggleChart={toggleChart} 
@@ -36,13 +71,13 @@ const DashboardView = (props) => {
                 handleRemove={handleRemove}
               />
             </Col>
-            <Col xs='12' lg='6'>
+            <Col xs='12' xl='6'>
               <SwapList
                 className='h-100'
                 header={'Recent Swaps'}
                 swaps={recentSwaps}/>
             </Col>
-            <Col xs='12' lg='6'>
+            <Col xs='12' xl='6'>
               <Card>
                 <CardHeader>
                   <h5>Distribution</h5>

--- a/src/app/components/Dashboard/view.jsx
+++ b/src/app/components/Dashboard/view.jsx
@@ -7,7 +7,7 @@ import Layout from 'Components/Layout'
 import BlockstackWelcome from 'Components/BlockstackWelcome'
 import Balances from 'Components/Balances'
 import Sidebar from 'Components/Sidebar'
-import WalleSelector from 'Components/WalletSelector'
+import WalletSelector from 'Components/WalletSelector'
 import TradeTable from 'Components/TradeTable'
 import { tableHeadings } from 'Components/TradeHistory'
 
@@ -24,9 +24,9 @@ const DashboardView = (props) => {
       }
       <Row className='gutter-3'>
         {!isDefaultPortfolioEmpty && (
-          <Col className='mt-2' xs='12' md='5' lg='4' xl='3'>
+          <Col xs='12' md='5' lg='4' xl='3'>
             <Sidebar className='d-none d-md-block'/>
-            <WalleSelector className='d-flex d-md-none'/>
+            <WalletSelector className='d-flex d-md-none'/>
           </Col>
         )}
         <Col xs='12' md='7' lg='8' xl='9'>

--- a/src/app/components/Dashboard/view.jsx
+++ b/src/app/components/Dashboard/view.jsx
@@ -1,27 +1,24 @@
 import React from 'react'
 import {
-  Row, Col,
+  Row, Col, Card, CardHeader, CardBody,
 } from 'reactstrap'
 
 import Layout from 'Components/Layout'
-import BlockstackWelcome from 'Components/BlockstackWelcome'
 import Balances from 'Components/Balances'
 import Sidebar from 'Components/Sidebar'
 import WalletSelector from 'Components/WalletSelector'
-import TradeTable from 'Components/TradeTable'
-import { tableHeadings } from 'Components/TradeHistory'
+import Address from 'Components/Address'
+import PieChart from 'Components/PieChart'
+import SwapList from 'Components/SwapList'
 
 const DashboardView = (props) => {
   const {
-    wallet, viewOnly, toggleChart, openCharts, handleRemove, isDefaultPortfolioEmpty,
-    pendingSwaps
+    wallet, toggleChart, openCharts, handleRemove, isDefaultPortfolioEmpty,
+    recentSwaps
   } = props
 
   return (
     <Layout className='pt-3'>
-      {!viewOnly &&
-        <BlockstackWelcome />
-      }
       <Row className='gutter-3'>
         {!isDefaultPortfolioEmpty && (
           <Col xs='12' md='5' lg='4' xl='3'>
@@ -39,13 +36,27 @@ const DashboardView = (props) => {
                 handleRemove={handleRemove}
               />
             </Col>
-            <Col xs='12'>
-              <TradeTable 
-                tableTitle='Open Orders'
-                swaps={pendingSwaps}
-                tableHeadings={tableHeadings}
-                hideIfNone
-              />
+            <Col xs='12' lg='6'>
+              <SwapList
+                className='h-100'
+                header={'Recent Swaps'}
+                swaps={recentSwaps}/>
+            </Col>
+            <Col xs='12' lg='6'>
+              <Card>
+                <CardHeader>
+                  <h5>Distribution</h5>
+                </CardHeader>
+                <CardBody>
+                  {wallet.address && (
+                    <div className='text-right' style={{ lineHeight: 1 }}>
+                      <Address address={wallet.address} />
+                      <small className='text-muted'>address</small>
+                    </div>
+                  )}
+                  <PieChart portfolio={wallet} />
+                </CardBody>
+              </Card>
             </Col>
           </Row>
         </Col>

--- a/src/app/components/Dashboard/view.jsx
+++ b/src/app/components/Dashboard/view.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import {
-  Row, Col, Card, CardHeader, CardBody,
+  Row, Col, Card, CardHeader, CardBody, Nav, NavItem, NavLink,
   UncontrolledDropdown, DropdownMenu, DropdownToggle, DropdownItem,
 } from 'reactstrap'
+import { NavLink as RouterNavLink } from 'react-router-dom'
 
 import { defaultPortfolioId } from 'Actions/portfolio'
+import routes from 'Routes'
 
 import Layout from 'Components/Layout'
 import Balances from 'Components/Balances'
@@ -25,6 +27,22 @@ const DashboardView = (props) => {
   return (
     <Layout className='pt-3'>
       <Row className='gutter-3'>
+        <Col xs='12'>
+          <Nav>
+            <NavItem className='ml-auto'>
+              <NavLink tag={RouterNavLink} to={routes.dashboard()}><i className='fa fa-list'/> Dashboard</NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink tag={RouterNavLink} to={routes.rebalance()}><i className='fa fa-sliders'/> Rebalance</NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink tag={RouterNavLink} to={routes.tradeHistory()}><i className='fa fa-history'/> Orders</NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink tag={RouterNavLink} to={routes.connect()}><i className='fa fa-plus'/> Add Wallet</NavLink>
+            </NavItem>
+          </Nav>
+        </Col>
         {!isDefaultPortfolioEmpty && (
           <Col xs='12' md='5' lg='4' xl='3'>
             <Sidebar className='d-none d-md-block'/>

--- a/src/app/components/Pair.jsx
+++ b/src/app/components/Pair.jsx
@@ -1,0 +1,26 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { compose, setDisplayName, setPropTypes } from 'recompose'
+
+import CoinIcon from 'Components/CoinIcon'
+
+const CoinSymbol = ({ symbol, ...props }) => (
+  <Fragment>
+    <CoinIcon className='mr-1' symbol={symbol} size='sm' inline {...props}/>
+    {symbol}
+  </Fragment>
+)
+
+export default compose(
+  setDisplayName('Pair'),
+  setPropTypes({
+    from: PropTypes.string, // asset symbol
+    to: PropTypes.string, // asset symbol
+  })
+)(({ from, to }) => (
+  <Fragment>
+    <CoinSymbol symbol={from}/>
+    <i className='fa fa-long-arrow-right text-grey mx-2'/> 
+    <CoinSymbol symbol={to}/>
+  </Fragment>
+))

--- a/src/app/components/RedirectPrefix.jsx
+++ b/src/app/components/RedirectPrefix.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose, setDisplayName, setPropTypes } from 'recompose'
+import { Route, Redirect } from 'react-router-dom'
+
+/**
+ * Very similar to normal inexact Redirect but does not erase nested routes.
+ * Useful when changing the top level route for many nested routes.
+ * 
+ * For example, using:
+ * `<Redirect from='/connect' to='/portfolio/connect'/>`
+ * Would redirect `/connect/hw/trezor` to `/portfolio/connect`. But using:
+ * `<RedirectPrefix from='/connect' to='/portfolio/connect'/>`
+ * Would redirect `/connect/hw/trezor` to `/portfolio/connect/hw/trezor`
+ */
+export default compose(
+  setDisplayName('RedirectPrefix'),
+  setPropTypes({
+    from: PropTypes.string,
+    to: PropTypes.string,
+  }),
+)(({ from, to }) => (
+  <Route path={from} render={props => (
+    <Redirect to={props.location.pathname.replace(from, to)}/>
+  )}/>
+))

--- a/src/app/components/SearchResults/index.jsx
+++ b/src/app/components/SearchResults/index.jsx
@@ -77,8 +77,6 @@ export default compose(
           <Balances 
             wallet={wallet}
             showStats={showStats}
-            handleAdd={() => handleAddToPortfolio(routes.dashboard())}
-            isAlreadyInPortfolio={isAlreadyInPortfolio}
           />
         </Col>
       </Row>

--- a/src/app/components/ShareButton.jsx
+++ b/src/app/components/ShareButton.jsx
@@ -18,8 +18,8 @@ export default compose(
     wallet: null,
   }),
   withToggle('open', false),
-)(({ wallet, isOpen, toggleOpen }) => (
-  <Button tag='span' color='' size='sm' disabled={!(wallet && wallet.address)} onClick={toggleOpen}>
+)(({ wallet, isOpen, toggleOpen, className }) => (
+  <Button tag='span' color='link' size='sm' className={className} disabled={!(wallet && wallet.address)} onClick={toggleOpen}>
     <Icon src={ShareIcon} style={{ width: '14px', fill: '#fff' }} />
     {wallet && (<ShareModal wallet={wallet} isOpen={isOpen} toggle={toggleOpen} />)}
   </Button>

--- a/src/app/components/Sidebar/index.jsx
+++ b/src/app/components/Sidebar/index.jsx
@@ -4,7 +4,7 @@ import { createStructuredSelector } from 'reselect'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 import {
-  ListGroup, ListGroupItem, Row, Col, Card, Badge, Media,
+  ListGroup, ListGroupItem, Card, Badge, Media,
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap'
 import { compose, setDisplayName, withState, withProps } from 'recompose'
@@ -25,7 +25,6 @@ import Units from 'Components/Units'
 import chart from 'Img/chart.svg?inline'
 import display from 'Utilities/display'
 import withToggle from 'Hoc/withToggle'
-import classNames from 'class-names'
 
 import { sidebarLabel } from './style'
 
@@ -41,236 +40,232 @@ const Sidebar = ({
   const portfolioBasedOnTimeFrame = timeFrame === '1d' ? totalFiat24hAgo : timeFrame === '7d' ? totalFiat7dAgo : totalFiat1hAgo
 
   return (
-    <Row className={classNames('gutter-3 align-items-end', className)}>
-      <Col xs='12'>
-        <Card>
-          <ListGroup>
-            <ListGroupItem className='text-center position-relative'>
-              <Icon style={{ top: '2px', left: 0, width: '100%', zIndex: 0 }} className='position-absolute' src={chart} />
-              <Dropdown group isOpen={isDropdownOpen} size="sm" toggle={toggleDropdownOpen}>
-                <DropdownToggle className='m-0 cursor-pointer' tag='p' caret>
-                  <small><Badge 
-                    className='mr-2 cursor-pointer font-size-xxs' 
-                    color='light'
-                  >
-                    {portfolioWalletIds.length}
-                  </Badge>{label}</small>
+    <Card className={className}>
+      <ListGroup>
+        <ListGroupItem className='text-center position-relative'>
+          <Icon style={{ top: '2px', left: 0, width: '100%', zIndex: 0 }} className='position-absolute' src={chart} />
+          <Dropdown group isOpen={isDropdownOpen} size="sm" toggle={toggleDropdownOpen}>
+            <DropdownToggle className='m-0 cursor-pointer' tag='p' caret>
+              <small><Badge 
+                className='mr-2 cursor-pointer font-size-xxs' 
+                color='light'
+              >
+                {portfolioWalletIds.length}
+              </Badge>{label}</small>
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem
+                onClick={() => setCurrentPortfolioAndWallet(currentPortfolioId, currentPortfolioId)}
+                active={currentWalletId === currentPortfolioId}
+              >
+                <WalletLabel.Connected id={currentPortfolioId} showBalance hideIcon/>
+              </DropdownItem>
+              <DropdownItem divider/>
+              {portfolioWalletIds.map((walletId) => (
+                <DropdownItem 
+                  key={walletId} 
+                  onClick={() => setCurrentPortfolioAndWallet(currentPortfolioId, walletId)}
+                  active={walletId === currentWalletId}
+                >
+                  <WalletLabel.Connected id={walletId} showBalance/>
+                </DropdownItem>
+              ))}
+            </DropdownMenu>
+          </Dropdown>
+          <div style={{ zIndex: 99 }} className='position-relative'>
+            <h2 className='m-0 mt-2 font-weight-bold'>{display.fiat(totalFiat)}</h2>
+            <ChangeFiat>{totalFiat.minus(portfolioBasedOnTimeFrame)}</ChangeFiat>
+            <small> <ChangePercent parentheses>{portfolioPercentChange}</ChangePercent></small>
+            <div>
+              <Badge 
+                className='mr-2 cursor-pointer' 
+                color={timeFrame == '7d' ? 'light' : 'ultra-dark'}
+                onClick={() => updateTimeFrame('7d')}
+              >
+                7d
+              </Badge>
+              <Badge 
+                className='mr-2 cursor-pointer' 
+                color={timeFrame == '1d' ? 'light' : 'ultra-dark'}
+                onClick={() => updateTimeFrame('1d')}
+              >
+                1d
+              </Badge>
+              <Badge 
+                className='cursor-pointer' 
+                color={timeFrame == '1h' ? 'light' : 'ultra-dark'}
+                onClick={() => updateTimeFrame('1h')}
+              >
+                1h
+              </Badge>
+            </div>
+          </div>
+        </ListGroupItem>
+        <ListGroupItem className='p-0 text-center'>
+          <small><p className={sidebarLabel}>Watchlist</p></small>
+          <div style={{ maxHeight: '171px', overflowY: 'auto' }}>
+            {watchlist.map((asset) => {
+              const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
+              const percentChange = timeFrame === '1d' ? change24 : timeFrame === '7d' ? change7d : change1
+              const priceChangeBasedOnTime = timeFrame === '1d' ? price24hAgo : timeFrame === '7d' ? price7dAgo : price1hAgo
+              return (
+                <Fragment key={symbol}>
+                  <Media style={{ borderBottom: '1px solid #292929' }} className='text-left px-3 py-0 cursor-pointer'>
+                    <Media left>
+                      <WatchlistStar className='pt-2 mt-1' symbol={symbol}/>
+                    </Media>
+                    <Media style={{ flex: '0 0 100%' }} onClick={() => push(`/assets/${symbol}`)}>
+                      <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
+                        <CoinIcon 
+                          symbol={symbol} 
+                          inline
+                          size='sm'
+                        /> 
+                        <Media className='m-0'>
+                          <span className='font-xxs'>{symbol}</span>
+                        </Media>
+                      </Media>
+                      <Media body>
+                        <Media className='m-0' heading>
+                          <Units className='font-xxs' symbol={'$'} value={price} symbolSpaced={false} expand={false} prefixSymbol></Units>
+                        </Media>
+                        <Media style={{ top: '-2px' }} className='position-relative'>
+                          <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
+                          <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
+                        </Media>
+                      </Media>
+                    </Media>
+                  </Media>
+                </Fragment>
+              )
+            })}
+          </div>
+        </ListGroupItem>
+        <ListGroupItem className='border-bottom-0 p-0 text-center'>
+          <small>
+            <div className={sidebarLabel}>Trending
+              <Dropdown group isOpen={isTrendingDropDownOpen} size="sm" toggle={toggleTrendingDropDownOpen}>
+                <DropdownToggle 
+                  tag='span' 
+                  style={{ lineHeight: '15px' }}
+                  className='cursor-pointer rounded border py-0 ml-1 px-1 flat' 
+                  size='sm' 
+                  color='ultra-dark' 
+                  caret
+                >
+                  <small>{trendingTimeFrame}</small>
                 </DropdownToggle>
-                <DropdownMenu>
-                  <DropdownItem
-                    onClick={() => setCurrentPortfolioAndWallet(currentPortfolioId, currentPortfolioId)}
-                    active={currentWalletId === currentPortfolioId}
-                  >
-                    <WalletLabel.Connected id={currentPortfolioId} showBalance hideIcon/>
-                  </DropdownItem>
-                  <DropdownItem divider/>
-                  {portfolioWalletIds.map((walletId) => (
-                    <DropdownItem 
-                      key={walletId} 
-                      onClick={() => setCurrentPortfolioAndWallet(currentPortfolioId, walletId)}
-                      active={walletId === currentWalletId}
-                    >
-                      <WalletLabel.Connected id={walletId} showBalance/>
-                    </DropdownItem>
-                  ))}
-                </DropdownMenu>
-              </Dropdown>
-              <div style={{ zIndex: 99 }} className='position-relative'>
-                <h2 className='m-0 mt-2 font-weight-bold'>{display.fiat(totalFiat)}</h2>
-                <ChangeFiat>{totalFiat.minus(portfolioBasedOnTimeFrame)}</ChangeFiat>
-                <small> <ChangePercent parentheses>{portfolioPercentChange}</ChangePercent></small>
-                <div>
-                  <Badge 
-                    className='mr-2 cursor-pointer' 
-                    color={timeFrame == '7d' ? 'light' : 'ultra-dark'}
-                    onClick={() => updateTimeFrame('7d')}
+                <DropdownMenu className='p-0'>
+                  <DropdownItem 
+                    active={trendingTimeFrame === '7d'}
+                    onClick={() => updateTrendingTimeFrame('7d')}
                   >
                     7d
-                  </Badge>
-                  <Badge 
-                    className='mr-2 cursor-pointer' 
-                    color={timeFrame == '1d' ? 'light' : 'ultra-dark'}
-                    onClick={() => updateTimeFrame('1d')}
+                  </DropdownItem>
+                  <DropdownItem className='m-0' divider/>
+                  <DropdownItem 
+                    active={trendingTimeFrame === '1d'}
+                    onClick={() => updateTrendingTimeFrame('1d')}
                   >
                     1d
-                  </Badge>
-                  <Badge 
-                    className='cursor-pointer' 
-                    color={timeFrame == '1h' ? 'light' : 'ultra-dark'}
-                    onClick={() => updateTimeFrame('1h')}
+                  </DropdownItem>
+                  <DropdownItem className='m-0' divider/>
+                  <DropdownItem 
+                    active={trendingTimeFrame === '1h'}
+                    onClick={() => updateTrendingTimeFrame('1h')}
                   >
                     1h
-                  </Badge>
-                </div>
-              </div>
-            </ListGroupItem>
-            <ListGroupItem className='p-0 text-center'>
-              <small><p className={sidebarLabel}>Watchlist</p></small>
-              <div style={{ maxHeight: '171px', overflowY: 'auto' }}>
-                {watchlist.map((asset) => {
-                  const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
-                  const percentChange = timeFrame === '1d' ? change24 : timeFrame === '7d' ? change7d : change1
-                  const priceChangeBasedOnTime = timeFrame === '1d' ? price24hAgo : timeFrame === '7d' ? price7dAgo : price1hAgo
-                  return (
-                    <Fragment key={symbol}>
-                      <Media style={{ borderBottom: '1px solid #292929' }} className='text-left px-3 py-0 cursor-pointer'>
-                        <Media left>
-                          <WatchlistStar className='pt-2 mt-1' symbol={symbol}/>
-                        </Media>
-                        <Media style={{ flex: '0 0 100%' }} onClick={() => push(`/assets/${symbol}`)}>
-                          <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
-                            <CoinIcon 
-                              symbol={symbol} 
-                              inline
-                              size='sm'
-                            /> 
-                            <Media className='m-0'>
-                              <span className='font-xxs'>{symbol}</span>
-                            </Media>
-                          </Media>
-                          <Media body>
-                            <Media className='m-0' heading>
-                              <Units className='font-xxs' symbol={'$'} value={price} symbolSpaced={false} expand={false} prefixSymbol></Units>
-                            </Media>
-                            <Media style={{ top: '-2px' }} className='position-relative'>
-                              <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
-                              <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
-                            </Media>
-                          </Media>
-                        </Media>
+                  </DropdownItem>
+                </DropdownMenu>
+              </Dropdown>
+            </div>
+          </small>
+          
+          <div style={{ maxHeight: '214px', overflowY: 'auto' }}>
+            {trendingPositive.map((asset, i) => {
+              const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
+              const percentChange = trendingTimeFrame === '1d' ? change24 : trendingTimeFrame === '7d' ? change7d : change1
+              const priceChangeBasedOnTime = trendingTimeFrame === '1d' ? price24hAgo : trendingTimeFrame === '7d' ? price7dAgo : price1hAgo
+              return (
+                <Fragment key={symbol}>
+                  <Media 
+                    onClick={() => push(`/assets/${symbol}`)}
+                    style={i !== trendingPositive.length - 1 ? { borderBottom: '1px solid #292929' } : {}} 
+                    className='text-left px-3 py-0 cursor-pointer'
+                  >
+                    <Media left>
+                      <small className='pt-2 mt-1 d-inline-block'>{i + 1}</small>
+                    </Media>
+                    <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
+                      <CoinIcon 
+                        symbol={symbol} 
+                        inline
+                        size='sm'
+                      /> 
+                      <Media className='m-0'>
+                        <span className='font-xxs'>{symbol}</span>
                       </Media>
-                    </Fragment>
-                  )
-                })}
-              </div>
-            </ListGroupItem>
-            <ListGroupItem className='border-bottom-0 p-0 text-center'>
-              <small>
-                <div className={sidebarLabel}>Trending
-                  <Dropdown group isOpen={isTrendingDropDownOpen} size="sm" toggle={toggleTrendingDropDownOpen}>
-                    <DropdownToggle 
-                      tag='span' 
-                      style={{ lineHeight: '15px' }}
-                      className='cursor-pointer rounded border py-0 ml-1 px-1 flat' 
-                      size='sm' 
-                      color='ultra-dark' 
-                      caret
+                    </Media>
+                    <Media body>
+                      <Media style={{ top: '1px' }} className='m-0 position-relative' heading>
+                        <small>
+                          <Units className='font-xs' symbol={'$'} value={price} expand={false} symbolSpaced={false} prefixSymbol></Units>
+                        </small>
+                      </Media>
+                      <Media style={{ top: '-2px' }} className='position-relative'>
+                        <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
+                        <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
+                      </Media>
+                    </Media>
+                  </Media>
+                </Fragment>
+              )
+            })}
+            <div style={{ borderTop: '1px dashed #292929' }} className='p-0 text-center'>
+              {trendingNegative.map((asset, i) => {
+                const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
+                const percentChange = trendingTimeFrame === '1d' ? change24 : trendingTimeFrame === '7d' ? change7d : change1
+                const priceChangeBasedOnTime = trendingTimeFrame === '1d' ? price24hAgo : trendingTimeFrame === '7d' ? price7dAgo : price1hAgo
+                return (
+                  <Fragment key={symbol}>
+                    <Media 
+                      onClick={() => push(`/assets/${symbol}`)}
+                      style={{ borderBottom: '1px solid #292929' }} 
+                      className='text-left px-3 py-0 cursor-pointer'
                     >
-                      <small>{trendingTimeFrame}</small>
-                    </DropdownToggle>
-                    <DropdownMenu className='p-0'>
-                      <DropdownItem 
-                        active={trendingTimeFrame === '7d'}
-                        onClick={() => updateTrendingTimeFrame('7d')}
-                      >
-                        7d
-                      </DropdownItem>
-                      <DropdownItem className='m-0' divider/>
-                      <DropdownItem 
-                        active={trendingTimeFrame === '1d'}
-                        onClick={() => updateTrendingTimeFrame('1d')}
-                      >
-                        1d
-                      </DropdownItem>
-                      <DropdownItem className='m-0' divider/>
-                      <DropdownItem 
-                        active={trendingTimeFrame === '1h'}
-                        onClick={() => updateTrendingTimeFrame('1h')}
-                      >
-                        1h
-                      </DropdownItem>
-                    </DropdownMenu>
-                  </Dropdown>
-                </div>
-              </small>
-              
-              <div style={{ maxHeight: '214px', overflowY: 'auto' }}>
-                {trendingPositive.map((asset, i) => {
-                  const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
-                  const percentChange = trendingTimeFrame === '1d' ? change24 : trendingTimeFrame === '7d' ? change7d : change1
-                  const priceChangeBasedOnTime = trendingTimeFrame === '1d' ? price24hAgo : trendingTimeFrame === '7d' ? price7dAgo : price1hAgo
-                  return (
-                    <Fragment key={symbol}>
-                      <Media 
-                        onClick={() => push(`/assets/${symbol}`)}
-                        style={i !== trendingPositive.length - 1 ? { borderBottom: '1px solid #292929' } : {}} 
-                        className='text-left px-3 py-0 cursor-pointer'
-                      >
-                        <Media left>
-                          <small className='pt-2 mt-1 d-inline-block'>{i + 1}</small>
-                        </Media>
-                        <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
-                          <CoinIcon 
-                            symbol={symbol} 
-                            inline
-                            size='sm'
-                          /> 
-                          <Media className='m-0'>
-                            <span className='font-xxs'>{symbol}</span>
-                          </Media>
-                        </Media>
-                        <Media body>
-                          <Media style={{ top: '1px' }} className='m-0 position-relative' heading>
-                            <small>
-                              <Units className='font-xs' symbol={'$'} value={price} expand={false} symbolSpaced={false} prefixSymbol></Units>
-                            </small>
-                          </Media>
-                          <Media style={{ top: '-2px' }} className='position-relative'>
-                            <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
-                            <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
-                          </Media>
+                      <Media left>
+                        <small className='pt-2 mt-1 d-inline-block'>{i + 1}</small>
+                      </Media>
+                      <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
+                        <CoinIcon 
+                          symbol={symbol} 
+                          inline
+                          size='sm'
+                        /> 
+                        <Media className='m-0'>
+                          <span className='font-xxs'>{symbol}</span>
                         </Media>
                       </Media>
-                    </Fragment>
-                  )
-                })}
-                <div style={{ borderTop: '1px dashed #292929' }} className='p-0 text-center'>
-                  {trendingNegative.map((asset, i) => {
-                    const { symbol, price, change24, change7d, change1, price24hAgo, price7dAgo, price1hAgo } = asset
-                    const percentChange = trendingTimeFrame === '1d' ? change24 : trendingTimeFrame === '7d' ? change7d : change1
-                    const priceChangeBasedOnTime = trendingTimeFrame === '1d' ? price24hAgo : trendingTimeFrame === '7d' ? price7dAgo : price1hAgo
-                    return (
-                      <Fragment key={symbol}>
-                        <Media 
-                          onClick={() => push(`/assets/${symbol}`)}
-                          style={{ borderBottom: '1px solid #292929' }} 
-                          className='text-left px-3 py-0 cursor-pointer'
-                        >
-                          <Media left>
-                            <small className='pt-2 mt-1 d-inline-block'>{i + 1}</small>
-                          </Media>
-                          <Media style={{ width: '35px' }} className='ml-4 mr-3' left>
-                            <CoinIcon 
-                              symbol={symbol} 
-                              inline
-                              size='sm'
-                            /> 
-                            <Media className='m-0'>
-                              <span className='font-xxs'>{symbol}</span>
-                            </Media>
-                          </Media>
-                          <Media body>
-                            <Media style={{ top: '1px' }} className='m-0 position-relative' heading>
-                              <small>
-                                <Units className='font-xs' symbol={'$'} value={price} expand={false} symbolSpaced={false} prefixSymbol></Units>
-                              </small>
-                            </Media>
-                            <Media style={{ top: '-2px' }} className='position-relative'>
-                              <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
-                              <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
-                            </Media>
-                          </Media>
+                      <Media body>
+                        <Media style={{ top: '1px' }} className='m-0 position-relative' heading>
+                          <small>
+                            <Units className='font-xs' symbol={'$'} value={price} expand={false} symbolSpaced={false} prefixSymbol></Units>
+                          </small>
                         </Media>
-                      </Fragment>
-                    )
-                  })}
-                </div>
-              </div>
-            </ListGroupItem>
-          </ListGroup>
-        </Card>
-      </Col>
-    </Row>
+                        <Media style={{ top: '-2px' }} className='position-relative'>
+                          <span className='font-xs mr-1'><ChangeFiat>{price.minus(priceChangeBasedOnTime)}</ChangeFiat></span>
+                          <span className='font-xs'><ChangePercent parentheses>{percentChange}</ChangePercent></span>
+                        </Media>
+                      </Media>
+                    </Media>
+                  </Fragment>
+                )
+              })}
+            </div>
+          </div>
+        </ListGroupItem>
+      </ListGroup>
+    </Card>
   )
 }
 

--- a/src/app/components/SwapList.jsx
+++ b/src/app/components/SwapList.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { compose, setDisplayName, setPropTypes, defaultProps } from 'recompose'
-import { Card, CardHeader, CardBody, CardFooter, ListGroup, ListGroupItem } from 'reactstrap'
+import { Card, CardHeader, CardBody, ListGroup, ListGroupItem } from 'reactstrap'
 import { Link } from 'react-router-dom'
 
 import routes from 'Routes'
-import Pair from 'Components/Pair'
+import SwapStatus from 'Components/SwapStatus'
+import Expandable from 'Components/Expandable'
 
 export default compose(
   setDisplayName('SwapList'),
@@ -29,19 +30,22 @@ export default compose(
     ) : (
       <ListGroup>
         {swaps.map((swap) => (
-          <ListGroupItem action key={swap.id} tag={Link} to={routes.tradeDetail(swap.orderId)}>
-            <div>
-              <Pair from={swap.sendSymbol} to={swap.receiveSymbol}/>
+          <ListGroupItem action className='pb-1' key={swap.id} tag={Link} to={routes.tradeDetail(swap.orderId)}>
+            <SwapStatus swap={swap} hideChange/>
+            <div className='text-right mt-1'>
+              <small className='text-muted'>
+                <Expandable
+                  shrunk={swap.createdAtFriendly}
+                  expanded={swap.createdAtFormatted}
+                />
+              </small>
             </div>
-            <small className='text-muted'>{swap.createdAtFriendly}</small>
           </ListGroupItem>
         ))}
+        <ListGroupItem action tag={Link} to={routes.tradeHistory()} className='text-center text-primary mt-auto'>
+          View all orders
+        </ListGroupItem>
       </ListGroup>
     )}
-    <CardFooter className='text-center mt-auto'>
-      <Link to={routes.tradeHistory()}>
-        View all orders
-      </Link>
-    </CardFooter>
   </Card>
 ))

--- a/src/app/components/SwapList.jsx
+++ b/src/app/components/SwapList.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose, setDisplayName, setPropTypes, defaultProps } from 'recompose'
+import { Card, CardHeader, CardBody, CardFooter, ListGroup, ListGroupItem } from 'reactstrap'
+import { Link } from 'react-router-dom'
+
+import routes from 'Routes'
+import Pair from 'Components/Pair'
+
+export default compose(
+  setDisplayName('SwapList'),
+  setPropTypes({
+    swaps: PropTypes.arrayOf(PropTypes.object),
+    header: PropTypes.string,
+  }),
+  defaultProps({
+    swaps: [],
+    header: 'Orders',
+  }),
+)(({ swaps, header, ...props }) => (
+  <Card {...props}>
+    <CardHeader>
+      <h5>{header}</h5>
+    </CardHeader>
+    {!swaps ? (
+      <CardBody>
+        <i>No {header.toLowerCase()}</i>
+      </CardBody>
+    ) : (
+      <ListGroup>
+        {swaps.map((swap) => (
+          <ListGroupItem action key={swap.id} tag={Link} to={routes.tradeDetail(swap.orderId)}>
+            <div>
+              <Pair from={swap.sendSymbol} to={swap.receiveSymbol}/>
+            </div>
+            <small className='text-muted'>{swap.createdAtFriendly}</small>
+          </ListGroupItem>
+        ))}
+      </ListGroup>
+    )}
+    <CardFooter className='text-center mt-auto'>
+      <Link to={routes.tradeHistory()}>
+        View all orders
+      </Link>
+    </CardFooter>
+  </Card>
+))

--- a/src/app/components/SwapStatus.jsx
+++ b/src/app/components/SwapStatus.jsx
@@ -77,7 +77,7 @@ export default compose(
   },
   before, after, shortStatus, showShortStatus, hideChange, className,
 }) => (
-  <Row className={classNames('gutter-0 font-size-small text-muted lh-0', className)}>
+  <Row className={classNames('gutter-0 align-items-center font-size-small text-muted lh-0', className)}>
     {before}
     <Col>
       <Row className='gutter-2 align-items-center text-center text-sm-left'>

--- a/src/app/components/SwapStatus.jsx
+++ b/src/app/components/SwapStatus.jsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose, setDisplayName, setPropTypes, defaultProps, withProps } from 'recompose'
+import { Row, Col } from 'reactstrap'
+import classNames from 'class-names'
+
+import ChangePercent from 'Components/ChangePercent'
+import ArrowIcon from 'Components/ArrowIcon'
+import PriceArrowIcon from 'Components/PriceArrowIcon'
+import CoinIcon from 'Components/CoinIcon'
+import Units from 'Components/Units'
+import UnitsLoading from 'Components/UnitsLoading'
+import Spinner from 'Components/Spinner'
+
+const priceChange = (date, asset) => {
+  const { change1, change7d, change24 } = asset
+  // falsey date => hasn't loaded yet so default to 1h change
+  date = new Date(date)
+  const hoursSinceTrade = !date ? 0 : (Date.now() - date.getTime()) / 3600000
+  const timespan = hoursSinceTrade <= 1 ? 'Last 1hr: ' : hoursSinceTrade >= 24 ? 'Last 7d: ' : 'Last 24hrs: '
+  var priceChange = hoursSinceTrade <= 1 ? change1 : hoursSinceTrade >= 24 ? change7d : change24
+  return (
+    <span>{timespan}
+      <ChangePercent>{priceChange}</ChangePercent>
+      <PriceArrowIcon 
+        className={classNames('swapChangeArrow', priceChange.isZero() ? 'd-none' : null)} 
+        size={.58} dir={priceChange < 0 ? 'down' : 'up'} 
+        color={priceChange < 0 ? 'danger' : priceChange > 0 ? 'success' : null}
+      />
+    </span>
+  )
+}
+
+const getShortStatus = (swap) => {
+  const { tx, status: { code, detailsCode, labelClass, label } } = swap
+  if (detailsCode === 'signed') {
+    return (<span className='text-success'>Signed</span>)
+  } else if (detailsCode === 'signing_unsupported') {
+    return (<span className='text-success'>Ready</span>)
+  } else if (detailsCode === 'signing') {
+    return (<span className='text-warning blink'>Awaiting signature</span>)
+  } else if (detailsCode.includes('error')) {
+    return (<span className='text-danger'>Failed</span>)
+  } else if (detailsCode === 'sending') {
+    return (<span className='text-primary'>Sending</span>)
+  } else if ((tx && tx.sent) || code === 'failed') {
+    return (<span className={labelClass}>{label}</span>)
+  } else if (detailsCode === 'unsigned') {
+    return null
+  } else if (detailsCode === 'creating_tx' || detailsCode === 'fetching_rate') {
+    return (<Spinner size='sm' inline/>)
+  }
+  return (<span>{label || code}</span>)
+}
+
+export default compose(
+  setDisplayName('SwapStatus'),
+  setPropTypes({
+    swap: PropTypes.object.isRequired,
+    showShortStatus: PropTypes.bool,
+    hideChange: PropTypes.bool,
+    before: PropTypes.node,
+    after: PropTypes.node,
+  }),
+  defaultProps({
+    showShortStatus: false,
+    hideChange: false,
+    before: null,
+    after: null,
+  }),
+  withProps(({ swap }) => ({
+    shortStatus: getShortStatus(swap),
+  })),
+)(({
+  swap: {
+    sendSymbol, sendAmount, sendAsset, createdAt, receiveSymbol, receiveAsset, receiveAmount, error,
+  },
+  before, after, shortStatus, showShortStatus, hideChange, className,
+}) => (
+  <Row className={classNames('gutter-0 font-size-small text-muted lh-0', className)}>
+    {before}
+    <Col>
+      <Row className='gutter-2 align-items-center text-center text-sm-left'>
+        <Col xs='12' sm='auto'><CoinIcon symbol={sendSymbol}/></Col>
+        <Col xs='12' sm>
+          <Row className='gutter-2'>
+            <Col xs='12' className='order-sm-2 font-size-sm pt-0'>{sendAsset.name}</Col>
+            {sendAmount ? (<Col xs='12' className='text-white'>
+              <Units value={sendAmount} symbol={sendSymbol} prefix='-'/>
+            </Col>) : null}
+            {sendAsset && !hideChange ? (<Col xs='12' className='mt-0 pt-0 order-sm-3 font-size-xs'>{priceChange(createdAt, sendAsset)}</Col>)
+              : null}
+          </Row>
+        </Col>
+      </Row>
+    </Col>
+    <Col xs='auto' className='text-center'>
+      <ArrowIcon inline size={1.5} dir='right' color={error ? 'danger' : 'success'}/><br/>
+      {showShortStatus && (<small className='lh-0'>{shortStatus}</small>)}
+    </Col>
+    <Col>
+      <Row className='gutter-2 align-items-center text-center text-sm-right'>
+        <Col xs='12' sm='auto' className='order-sm-2'><CoinIcon symbol={receiveSymbol}/></Col>
+        <Col xs='12' sm>
+          <Row className='gutter-2'>
+            <Col xs='12' className='order-sm-2 font-size-sm pt-0'>{receiveAsset ? receiveAsset.name : receiveSymbol}</Col>
+            {receiveAmount ? (<Col xs='12' className='text-white'>
+              <UnitsLoading value={receiveAmount} symbol={receiveSymbol} error={error} prefix='+'/>
+            </Col>) : null}
+            {receiveAsset && !hideChange  ? (<Col xs='12' className='mt-0 pt-0 order-sm-3 font-size-xs'>{priceChange(createdAt, receiveAsset)}</Col>)
+              : null}
+          </Row>
+        </Col>
+      </Row>
+    </Col>
+    {after}
+  </Row>
+))

--- a/src/app/components/SwapStatusCard.jsx
+++ b/src/app/components/SwapStatusCard.jsx
@@ -1,67 +1,22 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { compose, setDisplayName, setPropTypes, defaultProps, withProps } from 'recompose'
-import { Row, Col, Card, CardBody, CardFooter, Alert, Collapse, Button } from 'reactstrap'
+import { Col, Card, CardBody, CardFooter, Alert, Collapse, Button } from 'reactstrap'
 import classNames from 'class-names'
 import config from 'Config'
 import withToggle from '../hoc/withToggle'
 
-import ChangePercent from 'Components/ChangePercent'
-import ArrowIcon from 'Components/ArrowIcon'
-import PriceArrowIcon from 'Components/PriceArrowIcon'
-import CoinIcon from 'Components/CoinIcon'
-import Units from 'Components/Units'
 import UnitsLoading from 'Components/UnitsLoading'
 import WalletLabel from 'Components/WalletLabel'
 import Spinner from 'Components/Spinner'
 import DataLayout from 'Components/DataLayout'
+import SwapStatus from 'Components/SwapStatus'
 
 const StatusFooter = ({ className, children, ...props }) => (
   <CardFooter className={classNames('font-size-xs py-2 px-3', className)} {...props}>
     {children}
   </CardFooter>
 )
-
-const priceChange = (date, asset) => {
-  const { change1, change7d, change24 } = asset
-  // falsey date => hasn't loaded yet so default to 1h change
-  date = new Date(date)
-  const hoursSinceTrade = !date ? 0 : (Date.now() - date.getTime()) / 3600000
-  const timespan = hoursSinceTrade <= 1 ? 'Last 1hr: ' : hoursSinceTrade >= 24 ? 'Last 7d: ' : 'Last 24hrs: '
-  var priceChange = hoursSinceTrade <= 1 ? change1 : hoursSinceTrade >= 24 ? change7d : change24
-  return (
-    <span>{timespan}
-      <ChangePercent>{priceChange}</ChangePercent>
-      <PriceArrowIcon 
-        className={classNames('swapChangeArrow', priceChange.isZero() ? 'd-none' : null)} 
-        size={.58} dir={priceChange < 0 ? 'down' : 'up'} 
-        color={priceChange < 0 ? 'danger' : priceChange > 0 ? 'success' : null}
-      />
-    </span>
-  )
-}
-
-const getShortStatus = (swap) => {
-  const { tx, status: { code, detailsCode, labelClass, label } } = swap
-  if (detailsCode === 'signed') {
-    return (<span className='text-success'>Signed</span>)
-  } else if (detailsCode === 'signing_unsupported') {
-    return (<span className='text-success'>Ready</span>)
-  } else if (detailsCode === 'signing') {
-    return (<span className='text-warning blink'>Awaiting signature</span>)
-  } else if (detailsCode.includes('error')) {
-    return (<span className='text-danger'>Failed</span>)
-  } else if (detailsCode === 'sending') {
-    return (<span className='text-primary'>Sending</span>)
-  } else if ((tx && tx.sent) || code === 'failed') {
-    return (<span className={labelClass}>{label}</span>)
-  } else if (detailsCode === 'unsigned') {
-    return null
-  } else if (detailsCode === 'creating_tx' || detailsCode === 'fetching_rate') {
-    return (<Spinner size='sm' inline/>)
-  }
-  return (<span>{label || code}</span>)
-}
 
 /* eslint-disable react/jsx-key */
 export default compose(
@@ -81,21 +36,20 @@ export default compose(
     expanded: null
   }),
   withToggle('expandedState'),
-  withProps(({ swap, expanded, isExpandedState, toggleExpandedState }) => ({
+  withProps(({ expanded, isExpandedState, toggleExpandedState }) => ({
     isExpanded: expanded === null ? isExpandedState : expanded,
     togglerProps: expanded === null ? { tag: Button, color: 'ultra-dark', onClick: toggleExpandedState } : {},
-    shortStatus: getShortStatus(swap),
   }))
 )(({
-  swap: {
-    orderId, sendWalletId, sendSymbol, sendAsset, sendAmount,
-    receiveWalletId, receiveSymbol, receiveAsset, receiveAmount, receiveAddress,
+  swap, showShortStatus, showDetails, isExpanded, togglerProps, expanded
+}) => {
+  const {
+    orderId, sendWalletId, sendSymbol, sendAmount,
+    receiveWalletId, receiveSymbol, receiveAmount, receiveAddress,
     error, friendlyError, rate, fee: swapFee, hasFee: hasSwapFee,
     tx: { confirmed, succeeded, hash: txHash, feeAmount: txFee, feeSymbol: txFeeSymbol },
-    status: { code, details, detailsCode }, createdAt, createdAtFormatted, initializing, isManual
-  },
-  shortStatus, showShortStatus, showDetails, isExpanded, togglerProps, expanded
-}) => {
+    status: { code, details, detailsCode }, createdAtFormatted, initializing, isManual
+  } = swap
   const isComplete = code === 'complete'
   const loadingValue = (error
     ? (<span className='text-danger'>-</span>)
@@ -106,45 +60,15 @@ export default compose(
         className={classNames('py-2 pr-3 pl-2 border-0 lh-0', { 'py-3': !receiveAmount && !sendAmount })}
         style={{ minHeight: '4rem' }}
         {...togglerProps}>
-        <Row className='gutter-0 align-items-center font-size-small text-muted'>
-          <Col xs='auto'>
-            { expanded === null ? <i style={{ transition: 'all .15s ease-in-out' }} className={classNames('fa fa-chevron-circle-down text-primary px-2 mr-2', { ['fa-rotate-180']: isExpanded })}/> : false }
-          </Col>
-          <Col>
-            <Row className='gutter-2 align-items-center text-center text-sm-left'>
-              <Col xs='12' sm='auto'><CoinIcon symbol={sendSymbol}/></Col>
-              <Col xs='12' sm>
-                <Row className='gutter-2'>
-                  <Col xs='12' className='order-sm-2 font-size-sm pt-0'>{sendAsset.name}</Col>
-                  {sendAmount ? (<Col xs='12' className='text-white'>
-                    <Units value={sendAmount} symbol={sendSymbol} prefix='-'/>
-                  </Col>) : null}
-                  {sendAsset ? (<Col xs='12' className='mt-0 pt-0 order-sm-3 font-size-xs'>{priceChange(createdAt, sendAsset)}</Col>)
-                    : null}
-                </Row>
-              </Col>
-            </Row>
-          </Col>
-          <Col xs='auto' className='text-center'>
-            <ArrowIcon inline size={1.5} dir='right' color={error ? 'danger' : 'success'}/><br/>
-            {showShortStatus && (<small className='lh-0'>{shortStatus}</small>)}
-          </Col>
-          <Col>
-            <Row className='gutter-2 align-items-center text-center text-sm-right'>
-              <Col xs='12' sm='auto' className='order-sm-2'><CoinIcon symbol={receiveSymbol}/></Col>
-              <Col xs='12' sm>
-                <Row className='gutter-2'>
-                  <Col xs='12' className='order-sm-2 font-size-sm pt-0'>{receiveAsset ? receiveAsset.name : receiveSymbol}</Col>
-                  {receiveAmount ? (<Col xs='12' className='text-white'>
-                    <UnitsLoading value={receiveAmount} symbol={receiveSymbol} error={error} prefix='+'/>
-                  </Col>) : null}
-                  {receiveAsset ? (<Col xs='12' className='mt-0 pt-0 order-sm-3 font-size-xs'>{priceChange(createdAt, receiveAsset)}</Col>)
-                    : null}
-                </Row>
-              </Col>
-            </Row>
-          </Col>
-        </Row>
+        <SwapStatus swap={swap}
+          className='align-items-center'
+          showShortStatus={showShortStatus}
+          before={expanded === null && (
+            <Col xs='auto'>
+              <i style={{ transition: 'all .15s ease-in-out' }} className={classNames('fa fa-chevron-circle-down text-primary px-2 mr-2', { ['fa-rotate-180']: isExpanded })}/>
+            </Col>
+          )}
+        />
       </CardBody>
       {error 
         ? (<StatusFooter tag={Alert} color='danger' className='m-0 text-center'>{friendlyError || error}</StatusFooter>)

--- a/src/app/components/SwapStatusCard.jsx
+++ b/src/app/components/SwapStatusCard.jsx
@@ -61,7 +61,6 @@ export default compose(
         style={{ minHeight: '4rem' }}
         {...togglerProps}>
         <SwapStatus swap={swap}
-          className='align-items-center'
           showShortStatus={showShortStatus}
           before={expanded === null && (
             <Col xs='auto'>

--- a/src/app/components/TradeTable/index.jsx
+++ b/src/app/components/TradeTable/index.jsx
@@ -3,24 +3,16 @@ import { push as pushAction } from 'react-router-redux'
 import { connect } from 'react-redux'
 import { Table, Card, CardHeader } from 'reactstrap'
 import { compose, setDisplayName, withHandlers, defaultProps, setPropTypes } from 'recompose'
-import classNames from 'class-names'
 import PropTypes from 'prop-types'
 
 import routes from 'Routes'
 import Units from 'Components/Units'
 import Expandable from 'Components/Expandable'
-import CoinIcon from 'Components/CoinIcon'
+import Pair from 'Components/Pair'
 
-import { tradeTable, tradeCoinIcon } from './style'
+import { tradeTable } from './style'
 
 const NODATA = '-----'
-
-const CoinSymbol = ({ symbol, ...props }) => (
-  <Fragment>
-    <CoinIcon className={classNames(tradeCoinIcon, 'mr-1')} symbol={symbol} size='sm' inline {...props}/>
-    {symbol}
-  </Fragment>
-)
 
 const TableRow = ({
   swap,
@@ -31,9 +23,7 @@ const TableRow = ({
     <td>{createStatusLabel(swap)}</td>
     <td className='d-none d-sm-table-cell'>{createdAtFormatted}</td>
     <td className='d-none d-sm-table-cell'>
-      <CoinSymbol symbol={sendSymbol}/>
-      <i className='fa fa-long-arrow-right text-grey mx-2'/> 
-      <CoinSymbol symbol={receiveSymbol}/>
+      <Pair from={sendSymbol} to={receiveSymbol}/>
     </td>
     <td>{receiveAmount
       ? (<Units value={receiveAmount} symbol={receiveSymbol} precision={6} showSymbol showIcon iconProps={{ className: 'd-sm-none' }}/>)

--- a/src/app/components/WalletStats.jsx
+++ b/src/app/components/WalletStats.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose, setDisplayName, setPropTypes } from 'recompose'
+import { Row, Col } from 'reactstrap'
+import classNames from 'class-names'
+
+import { tag as tagPropType } from 'Utilities/propTypes'
+import display from 'Utilities/display'
+import ChangePercent from 'Components/ChangePercent'
+
+export default compose(
+  setDisplayName('WalletStats'),
+  setPropTypes({
+    wallet: PropTypes.object.isRequired,
+    tag: tagPropType,
+  }),
+)(({ tag: Tag, wallet }) => {
+  const {
+    totalFiat, totalFiat24hAgo, totalChange, shownAssetHoldings,
+  } = wallet
+  const stats = [
+    {
+      title: 'total assets',
+      value: shownAssetHoldings.length,
+      colClass: 'order-2 order-lg-1'
+    },
+    {
+      title: 'total balance',
+      value: display.fiat(totalFiat),
+      colClass: 'order-1 order-lg-2'
+    },
+    {
+      title: 'balance 24h ago',
+      value: display.fiat(totalFiat24hAgo),
+      colClass: 'order-3'
+    },
+    {
+      title: 'since 24h ago',
+      value: (<ChangePercent>{totalChange}</ChangePercent>),
+      colClass: 'order-4'
+    },
+  ]
+  return (
+    <Tag className='grid-group'>
+      <Row className='gutter-3'>
+        {stats.map(({ title, value, colClass }, i) => (
+          <Col xs='6' lg='3' key={i} className={classNames('text-center', colClass)}>
+            <div className='grid-cell'>
+              <div className='h3 mb-0'>{value}</div>
+              <small className='mb-0 text-muted text-uppercase letter-spacing'>{title}</small>
+            </div>
+          </Col>
+        ))}
+      </Row>
+    </Tag>
+  )
+})

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -36,19 +36,24 @@ const createPath = (...paths) => {
 }
 
 export const root = createPath('/')
-export const dashboard = createPath('/dashboard')
-export const rebalance = createPath('/rebalance')
+
+const portfolio = createPath('/portfolio')
+export const dashboard = portfolio
+export const rebalance = createPath(portfolio, '/rebalance')
 export const rebalanceInstructions = createPath(rebalance, '/instructions')
-export const viewOnlyAddress = createPath('/address/:addressQuery')
-export const tradeHistory = createPath('/orders')
+export const tradeHistory = createPath(portfolio, '/orders')
+
 export const tradeDetail = createPath('/orders/:tradeId')
 export const swapWidget = createPath('/swap')
-export const watchlist = createPath('/assets/watchlist')
-export const trending = createPath('/assets/trending')
-export const assetDetail = createPath('/assets/:symbol')
-export const assetIndex = createPath('/assets')
+export const viewOnlyAddress = createPath('/address/:addressQuery')
 
-export const connect = createPath('/connect')
+const assets = createPath('/assets')
+export const assetIndex = assets
+export const watchlist = createPath(assets, '/watchlist')
+export const trending = createPath(assets, '/trending')
+export const assetDetail = createPath(assets, '/:symbol')
+
+export const connect = createPath('/portfolio/connect')
 export const connectHwWallet = createPath(connect, '/hw/:walletType')
 export const walletInfoModal = createPath(connect, '/:walletType')
 export const connectHwWalletAsset = createPath(connectHwWallet, '/:assetSymbol')

--- a/src/app/selectors/swap.js
+++ b/src/app/selectors/swap.js
@@ -1,4 +1,6 @@
 import { createSelector } from 'reselect'
+import moment from 'moment'
+
 import { mapValues, dateSort } from 'Utilities/helpers'
 import {
   getSwapStatus, getSwapFriendlyError, getSwapRequiresSigning,
@@ -8,7 +10,6 @@ import { createItemSelector, selectItemId } from 'Utilities/selector'
 import { toBigNumber } from 'Utilities/convert'
 import { MultiWallet } from 'Services/Wallet'
 import { getAllWalletIds } from 'Selectors/wallet'
-import { formatDate } from 'Utilities/display'
 
 import { getAllAssets } from './asset'
 import { getAllWallets } from './wallet'
@@ -37,6 +38,8 @@ const createSwapExtender = (allAssets, allWallets, allTxs) => (swap) => {
   const sendWallet = allWallets[sendWalletId]
   const isManual = !sendWallet || sendWallet.isReadOnly
 
+  const createdAt = moment(swap.createdAt)
+
   swap = {
     ...swap,
     sendAmount: swap.sendAmount || swap.depositAmount,
@@ -51,7 +54,8 @@ const createSwapExtender = (allAssets, allWallets, allTxs) => (swap) => {
     receiveAsset,
     fee,
     hasFee: fee && fee.gt(0),
-    createdAtFormatted: formatDate(swap.createdAt, 'yyyy-MM-dd hh:mm:ss'),
+    createdAtFormatted: createdAt.format('YYYY-MM-DD hh:mm:ss'),
+    createdAtFriendly: createdAt.fromNow(),
     tx,
     txSigning: tx.signing,
     txSigned: tx.signed,
@@ -107,6 +111,11 @@ export const getConnectedWalletsPendingSwaps = createSelector(
   getConnectedWalletSentSwaps,
   (swaps) => swaps.filter(({ status: { code } }) => 
     code === 'pending')
+)
+
+export const getConnectedWalletsRecentSwaps = createSelector(
+  getConnectedWalletSentSwaps,
+  (swaps) => swaps.slice(0, 5),
 )
 
 export const getSwap = createItemSelector(

--- a/src/app/selectors/wallet.js
+++ b/src/app/selectors/wallet.js
@@ -153,6 +153,7 @@ export const getWalletWithHoldings = createItemSelector(
       assetHoldings,
       holdingsLoaded,
       holdingsError,
+      shownAssetHoldings: assetHoldings.filter(({ shown }) => shown),
     }
     return result
   }


### PR DESCRIPTION
Goal: Clean up pages into a more organized structure.

Tasks:
- [x] Move dashboard, rebalance, orders, and add wallet under new "portfolio" tab
- [x] Add recent orders card to dashboard
- [x] Split portfolio summary away from Balances component
- [ ] Fix order detail page routing
- [ ] Make sidebar show on all portfolio pages
- [ ] Add secondary nav on all portfolio pages
- [ ] Make order status page independent of order history page